### PR TITLE
Move base image to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM ubuntu:14.04.3
+FROM alpine:3.4
 MAINTAINER technik@myfoodmap.de
 
-RUN apt-get update && apt-get install -y \
-  python-pip \
-  xz-utils
+RUN apk add --update \
+    py-pip \
+    gpgme \
+    xz \
+    && rm -rf /var/cache/apk/*
 
 RUN pip install awscli
 

--- a/backup.sh
+++ b/backup.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-: ${BACKUP_DATE:=_$(date +"%Y-%m-%d_%H-%M")}
+BACKUP_DATE=$(date +"%Y-%m-%d_%H-%M")
 
 cd /backup
 tar cJf ~/$S3_BUCKET_NAME$BACKUP_DATE.tar.xz ./*

--- a/restore.sh
+++ b/restore.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 gpg --import /keys/*
 
 aws s3 ls s3://$S3_BUCKET_NAME

--- a/run.sh
+++ b/run.sh
@@ -1,14 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
+# Import GPG public keys
 gpg --import /keys/*
 
-cron
-
-# LS_COLORS is set to nothing and for some strange reason crontabs are not allowed to contain such env vars
-unset LS_COLORS
-
-# Create crontab file
-env | cat - > /backup.cron
+# Create and install crontab file
 echo "$CRON_INTERVAL /backup.sh" >> /backup.cron
 
 crontab /backup.cron


### PR DESCRIPTION
I changed your Dockerfile to use Alpine 3.4 and the image is now shrinked to ~95MB (#1). Since I had to change the scripts and have (so far...) no AWS account, can you please test if it is working as expected? 
